### PR TITLE
fix edit user 1/n

### DIFF
--- a/src/scenes/auth/index.css
+++ b/src/scenes/auth/index.css
@@ -6,6 +6,7 @@
   background-color: white;
   align-items: center;
   margin-top: 20px;
+  margin-bottom: 20px;
   padding: 20px;
   box-shadow: 0 2px 6px 0 #e4e4e4;
 }


### PR DESCRIPTION
Plusieurs fix (mais j'en aurai probablement d'autres) : 
 - Les modifications n'étaient pas prises en compte (corrigé principalement ici: https://github.com/betagouv/pop-production/compare/fix-edit-user-1-n?expand=1#diff-fbb230275935324090abed5cee5583c9R97)
- Rechargement de l'utilisateur à la fin du process (actuellement même si les modifications avaient été prises en compte, elles n'auraient pas été affichées ensuite, on aurait vu les anciennes (corrigé principalement ici : https://github.com/betagouv/pop-production/compare/fix-edit-user-1-n?expand=1#diff-fbb230275935324090abed5cee5583c9R107)
- Ajout d'une marge en bas pour éviter que la boite d'édition soit collée en bas
- Redirection vers une page recherche avec un toaster succès plutôt qu'un cul-de-sac (actuellement on arrivait dans une impasse).
- Remise en forme auto avec Prettier (dsl, ça se fait tout seul)

Ticket : https://trello.com/c/TuFWFyII/9-permettre-de-modifier-les-informations-personnelles