### PR TITLE
Fix search exists

### DIFF
--- a/src/scenes/search/components/queryBuilder/Rule.js
+++ b/src/scenes/search/components/queryBuilder/Rule.js
@@ -26,7 +26,6 @@ function getQuery(valueSelected, actionSelected, resultSelected) {
         ]
       }
     };
-    // return { term: toKeywordObject(valueSelected, "") };
   } else if (actionSelected === "==" && resultSelected) {
     // { value: "==", text: "égal à" },
     return { term: { [`${valueSelected}.keyword`]: resultSelected } };

--- a/src/scenes/search/components/queryBuilder/Rule.js
+++ b/src/scenes/search/components/queryBuilder/Rule.js
@@ -2,12 +2,6 @@ import React from "react";
 import Autocomplete from "react-autocomplete";
 import { ReactiveComponent } from "@appbaseio/reactivesearch";
 
-const toKeywordObject = (k, v) => {
-  const obj = {};
-  obj[`${k}.keyword`] = v;
-  return obj;
-};
-
 function getQuery(valueSelected, actionSelected, resultSelected) {
   if (actionSelected === "<>") {
     // { value: "<>", text: "exist" },
@@ -16,7 +10,7 @@ function getQuery(valueSelected, actionSelected, resultSelected) {
         // Must exists ...
         must: { exists: { field: valueSelected } },
         // ... and must be not empty.
-        must_not: { term: toKeywordObject(valueSelected, "") }
+        must_not: { term: { [`${valueSelected}.keyword`]: "" } }
       }
     };
   } else if (actionSelected === "><") {
@@ -25,8 +19,8 @@ function getQuery(valueSelected, actionSelected, resultSelected) {
       bool: {
         // Should be ...
         should: [
-          // ... empty string ... 
-          { term: toKeywordObject(valueSelected, "") },
+          // ... empty string ...
+          { term: { [`${valueSelected}.keyword`]: "" } },
           // ... or not exists.
           { bool: { must_not: { exists: { field: valueSelected } } } }
         ]
@@ -35,30 +29,32 @@ function getQuery(valueSelected, actionSelected, resultSelected) {
     // return { term: toKeywordObject(valueSelected, "") };
   } else if (actionSelected === "==" && resultSelected) {
     // { value: "==", text: "égal à" },
-    return { term: toKeywordObject(valueSelected, resultSelected) };
+    return { term: { [`${valueSelected}.keyword`]: resultSelected } };
   } else if (actionSelected === "!=" && resultSelected) {
     // { value: "!=", text: "différent de" },
     return {
-      must_not: { term: toKeywordObject(valueSelected, resultSelected) }
+      must_not: { term: { [`${valueSelected}.keyword`]: resultSelected } }
     };
   } else if (actionSelected === ">=" && resultSelected) {
     // { value: ">=", text: "supérieur ou égal à" },
-    return { range: toKeywordObject(valueSelected, { gte: resultSelected }) };
+    return { range: { [`${valueSelected}.keyword`]: { gte: resultSelected } } };
   } else if (actionSelected === "<=" && resultSelected) {
     // { value: "<=", text: "inférieur ou égal à" },
-    return { range: toKeywordObject(valueSelected, { lte: resultSelected }) };
+    return { range: { [`${valueSelected}.keyword`]: { lte: resultSelected } } };
   } else if (actionSelected === "<" && resultSelected) {
     // { value: "<", text: "strictement inférieur à" },
-    return { range: toKeywordObject(valueSelected, { lt: resultSelected }) };
+    return { range: { [`${valueSelected}.keyword`]: { lt: resultSelected } } };
   } else if (actionSelected === ">" && resultSelected) {
     // { value: ">", text: "strictement supérieur à" },
-    return { range: toKeywordObject(valueSelected, { gt: resultSelected }) };
+    return { range: { [`${valueSelected}.keyword`]: { gt: resultSelected } } };
   } else if (actionSelected === "^" && resultSelected) {
     // { value: "^", text: "commence par" }
-    return { wildcard: toKeywordObject(valueSelected, `${resultSelected}*`) };
+    return { wildcard: { [`${valueSelected}.keyword`]: `${resultSelected}*` } };
   } else if (actionSelected === "*" && resultSelected) {
     // { value: "*", text: "contient" }
-    return { wildcard: toKeywordObject(valueSelected, `*${resultSelected}*`) };
+    return {
+      wildcard: { [`${valueSelected}.keyword`]: `*${resultSelected}*` }
+    };
   } else {
     return null;
   }

--- a/src/scenes/search/components/queryBuilder/Rule.js
+++ b/src/scenes/search/components/queryBuilder/Rule.js
@@ -1,55 +1,49 @@
 import React from "react";
 import Autocomplete from "react-autocomplete";
-
 import { ReactiveComponent } from "@appbaseio/reactivesearch";
+
+const toKeywordObject = (k, v) => {
+  const obj = {};
+  obj[`${k}.keyword`] = v;
+  return obj;
+};
 
 function getQuery(valueSelected, actionSelected, resultSelected) {
   if (actionSelected === "<>") {
     // { value: "<>", text: "exist" },
-    return { exists: { field: valueSelected } };
+    return {
+      bool: {
+        must: { exists: { field: valueSelected } },
+        must_not: { term: toKeywordObject(valueSelected, "") }
+      }
+    };
   } else if (actionSelected === "><") {
     // { value: "><", text: "n'existe pas" }
-    return { bool: { must_not: { exists: { field: valueSelected } } } };
+    return { term: toKeywordObject(valueSelected, "") };
   } else if (actionSelected === "==" && resultSelected) {
     // { value: "==", text: "égal à" },
-    const obj = {};
-    obj[`${valueSelected}.keyword`] = resultSelected;
-    return { term: obj };
+    return { term: toKeywordObject(valueSelected, resultSelected) };
   } else if (actionSelected === "!=" && resultSelected) {
     // { value: "!=", text: "différent de" },
-    const obj = {};
-    obj[`${valueSelected}.keyword`] = resultSelected;
-    return { must_not: { term: obj } };
+    return { must_not: { term: toKeywordObject(valueSelected, resultSelected) } };
   } else if (actionSelected === ">=" && resultSelected) {
     // { value: ">=", text: "supérieur ou égal à" },
-    const obj = {};
-    obj[`${valueSelected}.keyword`] = { gte: resultSelected };
-    return { range: obj };
+    return { range: toKeywordObject(valueSelected, { gte: resultSelected }) };
   } else if (actionSelected === "<=" && resultSelected) {
     // { value: "<=", text: "inférieur ou égal à" },
-    const obj = {};
-    obj[`${valueSelected}.keyword`] = { lte: resultSelected };
-    return { range: obj };
+    return { range: toKeywordObject(valueSelected, { lte: resultSelected }) };
   } else if (actionSelected === "<" && resultSelected) {
     // { value: "<", text: "strictement inférieur à" },
-    const obj = {};
-    obj[`${valueSelected}.keyword`] = { lt: resultSelected };
-    return { range: obj };
+    return { range: toKeywordObject(valueSelected, { lt: resultSelected })  };
   } else if (actionSelected === ">" && resultSelected) {
     // { value: ">", text: "strictement supérieur à" },
-    const obj = {};
-    obj[`${valueSelected}.keyword`] = { gt: resultSelected };
-    return { range: obj };
+    return { range: toKeywordObject(valueSelected, { gt: resultSelected })  };
   } else if (actionSelected === "^" && resultSelected) {
     // { value: "^", text: "commence par" }
-    const obj = {};
-    obj[`${valueSelected}.keyword`] = `${resultSelected}*`;
-    return { wildcard: obj };
+    return { wildcard: toKeywordObject(valueSelected, `${resultSelected}*`)  };
   } else if (actionSelected === "*" && resultSelected) {
     // { value: "*", text: "contient" }
-    const obj = {};
-    obj[`${valueSelected}.keyword`] = `*${resultSelected}*`;
-    return { wildcard: obj };
+    return { wildcard: toKeywordObject(valueSelected, `*${resultSelected}*`)  };
   } else {
     return null;
   }

--- a/src/scenes/search/components/queryBuilder/Rule.js
+++ b/src/scenes/search/components/queryBuilder/Rule.js
@@ -13,19 +13,34 @@ function getQuery(valueSelected, actionSelected, resultSelected) {
     // { value: "<>", text: "exist" },
     return {
       bool: {
+        // Must exists ...
         must: { exists: { field: valueSelected } },
+        // ... and must be not empty.
         must_not: { term: toKeywordObject(valueSelected, "") }
       }
     };
   } else if (actionSelected === "><") {
     // { value: "><", text: "n'existe pas" }
-    return { term: toKeywordObject(valueSelected, "") };
+    return {
+      bool: {
+        // Should be ...
+        should: [
+          // ... empty string ... 
+          { term: toKeywordObject(valueSelected, "") },
+          // ... or not exists.
+          { bool: { must_not: { exists: { field: valueSelected } } } }
+        ]
+      }
+    };
+    // return { term: toKeywordObject(valueSelected, "") };
   } else if (actionSelected === "==" && resultSelected) {
     // { value: "==", text: "égal à" },
     return { term: toKeywordObject(valueSelected, resultSelected) };
   } else if (actionSelected === "!=" && resultSelected) {
     // { value: "!=", text: "différent de" },
-    return { must_not: { term: toKeywordObject(valueSelected, resultSelected) } };
+    return {
+      must_not: { term: toKeywordObject(valueSelected, resultSelected) }
+    };
   } else if (actionSelected === ">=" && resultSelected) {
     // { value: ">=", text: "supérieur ou égal à" },
     return { range: toKeywordObject(valueSelected, { gte: resultSelected }) };
@@ -34,16 +49,16 @@ function getQuery(valueSelected, actionSelected, resultSelected) {
     return { range: toKeywordObject(valueSelected, { lte: resultSelected }) };
   } else if (actionSelected === "<" && resultSelected) {
     // { value: "<", text: "strictement inférieur à" },
-    return { range: toKeywordObject(valueSelected, { lt: resultSelected })  };
+    return { range: toKeywordObject(valueSelected, { lt: resultSelected }) };
   } else if (actionSelected === ">" && resultSelected) {
     // { value: ">", text: "strictement supérieur à" },
-    return { range: toKeywordObject(valueSelected, { gt: resultSelected })  };
+    return { range: toKeywordObject(valueSelected, { gt: resultSelected }) };
   } else if (actionSelected === "^" && resultSelected) {
     // { value: "^", text: "commence par" }
-    return { wildcard: toKeywordObject(valueSelected, `${resultSelected}*`)  };
+    return { wildcard: toKeywordObject(valueSelected, `${resultSelected}*`) };
   } else if (actionSelected === "*" && resultSelected) {
     // { value: "*", text: "contient" }
-    return { wildcard: toKeywordObject(valueSelected, `*${resultSelected}*`)  };
+    return { wildcard: toKeywordObject(valueSelected, `*${resultSelected}*`) };
   } else {
     return null;
   }


### PR DESCRIPTION
Ok c'est un peu casse gueule la recherche de champ vide avec ElasticSearch quand on veut à la fois les "champs vide" ou "contenant une chaine vide". ET inversement quand on veut "champ existant" et "ne contenant pas une chaine vide". D'après mes tests c'est bon.

Voir : https://trello.com/c/ZIDuljgI/101-operateur-rche-experte-r%C3%A9parer-lop%C3%A9rateur-existe-existe-pas