### PR TITLE
a bit more security and readability

### DIFF
--- a/src/scenes/admin/createUser.js
+++ b/src/scenes/admin/createUser.js
@@ -51,7 +51,7 @@ class CreateUser extends React.Component {
   renderModal() {
     let groups = [];
 
-    if (this.props.group === "admin") {
+    if (this.props.role === "administrateur" && this.props.group === "admin") {
       groups = groups.concat([
         "admin",
         "mnr",
@@ -66,7 +66,7 @@ class CreateUser extends React.Component {
     groups = groups.map(e => <option key={e}>{e}</option>);
 
     let roles = [];
-    if (this.props.role === "administrateur" || this.props.group === "admin") {
+    if (this.props.role === "administrateur") {
       roles = roles.concat(["administrateur", "producteur", "utilisateur"]);
     }
 

--- a/src/scenes/admin/createUser.js
+++ b/src/scenes/admin/createUser.js
@@ -20,7 +20,22 @@ class CreateUser extends React.Component {
 
   createUser() {
     this.setState({ loading: true });
-    const { group, email, role, institution, prenom, nom, museofile } = this.state;
+    const {
+      group,
+      email,
+      role,
+      institution,
+      prenom,
+      nom,
+      museofile
+    } = this.state;
+    if (group === "admin" && role !== "administrateur") {
+      this.setState({
+        error:
+          "Les membres du groupe « admin » doivent avoir le rôle « administrateur »"
+      });
+      return;
+    }
     api
       .createUser(email, group, role, institution, prenom, nom, museofile)
       .then(() => {
@@ -38,7 +53,9 @@ class CreateUser extends React.Component {
 
     return (
       <div className="input-container">
-        <div>Code Musée<em class="text-muted"> - MUSEOFILE</em></div>
+        <div>
+          Code Musée<em class="text-muted"> - MUSEOFILE</em>
+        </div>
         <Input
           value={this.state.museofile}
           placeholder="Exemple : M5043"

--- a/src/scenes/admin/createUser.js
+++ b/src/scenes/admin/createUser.js
@@ -51,7 +51,7 @@ class CreateUser extends React.Component {
   renderModal() {
     let groups = [];
 
-    if (this.props.role === "administrateur" && this.props.group === "admin") {
+    if (this.props.group === "admin") {
       groups = groups.concat([
         "admin",
         "mnr",

--- a/src/scenes/admin/index.js
+++ b/src/scenes/admin/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Table } from "reactstrap";
 import CreateUser from "./createUser";
 import { connect } from "react-redux";
+import { Redirect } from "react-router-dom";
 import api from "../../services/api";
 
 import "./index.css";
@@ -20,43 +21,45 @@ class Admin extends React.Component {
   }
 
   renderUsers() {
-    return <Table>
-      <thead>
-        <tr>
-          <th>Email</th>
-          <th>Nom</th>
-          <th>Prénom</th>
-          <th>Groupe</th>
-          <th>Institution</th>
-          <th>Role</th>
-        </tr>
-      </thead>
-      <tbody>
-        {this.state.users.map(user => {
-          const { email, prenom, nom, role, institution, group } = user;
-          return (
-            <tr key={email}>
-              <td>{email}</td>
-              <td>{nom}</td>
-              <td>{prenom}</td>
-              <td>{group}</td>
-              <td>{institution}</td>
-              <td>{role}</td>
-            </tr>
-          );
-        })}
-      </tbody>
+    return (
+      <Table>
+        <thead>
+          <tr>
+            <th>Email</th>
+            <th>Nom</th>
+            <th>Prénom</th>
+            <th>Groupe</th>
+            <th>Institution</th>
+            <th>Role</th>
+          </tr>
+        </thead>
+        <tbody>
+          {this.state.users.map(user => {
+            const { email, prenom, nom, role, institution, group } = user;
+            return (
+              <tr key={email}>
+                <td>{email}</td>
+                <td>{nom}</td>
+                <td>{prenom}</td>
+                <td>{group}</td>
+                <td>{institution}</td>
+                <td>{role}</td>
+              </tr>
+            );
+          })}
+        </tbody>
       </Table>
-    ;
+    );
   }
 
   render() {
+    if (this.props.role !== "administrateur") {
+      return <Redirect to="/recherche" />;
+    }
     return (
       <div className="admin">
         <CreateUser />
-        <div className="usersList">
-          {this.renderUsers()}
-        </div>
+        <div className="usersList">{this.renderUsers()}</div>
       </div>
     );
   }
@@ -64,7 +67,8 @@ class Admin extends React.Component {
 
 const mapStateToProps = ({ Auth }) => {
   return {
-    group: Auth.user ? Auth.user.group : ""
+    group: Auth.user ? Auth.user.group : "",
+    role: Auth.user ? Auth.user.role : ""
   };
 };
 

--- a/src/scenes/auth/UpdateProfile.js
+++ b/src/scenes/auth/UpdateProfile.js
@@ -20,22 +20,18 @@ class UpdateProfile extends Component {
     hasResetPassword: false,
     nom: "",
     prenom: "",
-    institution: "",
-    group: "",
-    role: ""
+    institution: ""
   };
 
   componentWillMount() {
     const { user } = this.props;
     if (user) {
-      const { hasResetPassword, nom, prenom, institution, group, role } = user;
+      const { hasResetPassword, nom, prenom, institution } = user;
       this.setState({
         hasResetPassword,
         nom,
         prenom,
-        institution,
-        group,
-        role
+        institution
       });
     }
   }
@@ -44,14 +40,12 @@ class UpdateProfile extends Component {
     const { user } = this.props;
     const { user: prevUser } = prevProps;
     if (user && user !== prevUser) {
-      const { hasResetPassword, nom, prenom, institution, group, role } = user;
+      const { hasResetPassword, nom, prenom, institution } = user;
       this.setState({
         hasResetPassword,
         nom,
         prenom,
-        institution,
-        group,
-        role
+        institution
       });
     }
   }
@@ -77,18 +71,24 @@ class UpdateProfile extends Component {
       ppwd2,
       nom: stateNom,
       prenom: statePrenom,
-      institution: stateInstitution,
-      group: stateGroup,
-      role: stateRole
+      institution: stateInstitution
     } = this.state;
+
+    if (group === "admin" && role !== "administrateur") {
+      this.setState({
+        error:
+          "Les membres du groupe « admin » doivent avoir le rôle « administrateur »",
+        loading: false,
+        done: false
+      });
+      return;
+    }
 
     const hasChangedPassword = ppwd !== "" && ppwd1 !== "" && ppwd2 !== "";
     const hasChangedProfileInfo =
       nom !== stateNom ||
       prenom !== statePrenom ||
-      institution !== stateInstitution ||
-      group !== stateGroup ||
-      role !== stateRole;
+      institution !== stateInstitution;
     let promise = Promise.resolve();
 
     if (hasChangedProfileInfo) {
@@ -99,8 +99,8 @@ class UpdateProfile extends Component {
             stateNom,
             statePrenom,
             stateInstitution,
-            stateGroup,
-            stateRole
+            group,
+            role
           );
         })
         .then(() => {
@@ -154,35 +154,6 @@ class UpdateProfile extends Component {
     );
   }
 
-  renderGroups = () => {
-    const { group } = this.state;
-    let groupes = [];
-
-    if (group === "admin") {
-      groupes = groupes.concat([
-        "admin",
-        "mnr",
-        "joconde",
-        "mh",
-        "inv",
-        "memoire"
-      ]);
-    } else {
-      groupes.push(group);
-    }
-    return groupes.map((e, i) => <option key={`${e}${i}`}>{e}</option>);
-  };
-
-  renderRoles = () => {
-    const { role } = this.state;
-    let roles = [];
-    if (role === "administrateur") {
-      roles = roles.concat(["utilisateur", "producteur", "administrateur"]);
-    }
-
-    return roles.map((e, i) => <option key={`${e}${i}`}>{e}</option>);
-  };
-
   handleChange = name => event => {
     this.setState({
       [name]: event.target.value
@@ -197,9 +168,7 @@ class UpdateProfile extends Component {
       error,
       nom,
       prenom,
-      institution,
-      group,
-      role
+      institution
     } = this.state;
 
     if (loading) {
@@ -251,30 +220,6 @@ class UpdateProfile extends Component {
               value={institution}
               onChange={this.handleChange("institution")}
             />
-          </div>
-          <hr />
-          <div className="sub-block">
-            <h4>Mes groupes et roles</h4>
-            {group === "admin" ? (
-              <Input
-                type="select"
-                value={group}
-                onChange={this.handleChange("group")}
-                className="input-field select-field"
-              >
-                {this.renderGroups()}
-              </Input>
-            ) : null}
-            {role === "administrateur" ? (
-              <Input
-                type="select"
-                value={role}
-                onChange={this.handleChange("role")}
-                className="input-field select-field"
-              >
-                {this.renderRoles()}
-              </Input>
-            ) : null}
           </div>
           <hr />
           <div className="sub-block">

--- a/src/scenes/auth/UpdateProfile.js
+++ b/src/scenes/auth/UpdateProfile.js
@@ -174,9 +174,9 @@ class UpdateProfile extends Component {
   };
 
   renderRoles = () => {
-    const { group, role } = this.state;
+    const { role } = this.state;
     let roles = [];
-    if (role === "administrateur" || group === "admin") {
+    if (role === "administrateur") {
       roles = roles.concat(["utilisateur", "producteur", "administrateur"]);
     }
 
@@ -265,7 +265,7 @@ class UpdateProfile extends Component {
                 {this.renderGroups()}
               </Input>
             ) : null}
-            {role === "administrateur" || group === "admin" ? (
+            {role === "administrateur" ? (
               <Input
                 type="select"
                 value={role}

--- a/src/scenes/header/index.js
+++ b/src/scenes/header/index.js
@@ -18,14 +18,12 @@ class NavComponent extends React.Component {
           <Link to="/">Accueil</Link>
           <Link to="/recherche">Recherche</Link>
           {this.props.role === "administrateur" ||
-          this.props.role === "producteur" ||
-          this.props.group === "admin" ? (
+          this.props.role === "producteur" ? (
             <Link to="/import">Import</Link>
           ) : (
             <div />
           )}
-          {this.props.role === "administrateur" ||
-          this.props.group === "admin" ? (
+          {this.props.role === "administrateur" ? (
             <Link to="/admin">Administration</Link>
           ) : (
             <div />


### PR DESCRIPTION
Un admin doit nécessairement avoir le rôle administrateur
 - Donc ça ne sert à rien de faire : `this.props.role === "administrateur" || this.props.group === "admin"`. Ça peut être simpifié en `this.props.role === "administrateur"`.

Par ailleurs : 
 - On redirige ceux qui arrivent sur la page d'admin alors qu'ils n'ont pas de droits (ça m'a fait un truc bizarre en changeant de droits) : https://github.com/betagouv/pop-production/compare/security-and-readability?expand=1#diff-6d8f046836d3f201331db5354fc801eaR56
 - Il n'est plus possible de changer soi-même de rôle ou de groupe, ça enlève une partie de la complexité du code.