### PR TITLE
change limitation from 10000 to 5000

### DIFF
--- a/src/scenes/search/components/export.js
+++ b/src/scenes/search/components/export.js
@@ -52,7 +52,7 @@ export default class ExportComponent extends React.Component {
         react={{ and: this.props.FILTER }}
         onAllData={(results, streamResults, loadMoreData) => {
           const res = this.state.res.concat(results);
-          if (!results.length || res.length === 10000) {
+          if (!results.length || res.length === 5000) {
             this.exec(res);
           } else {
             this.setState({ page: (this.state.page += 1), res });

--- a/src/scenes/search/components/export.js
+++ b/src/scenes/search/components/export.js
@@ -52,7 +52,7 @@ export default class ExportComponent extends React.Component {
         react={{ and: this.props.FILTER }}
         onAllData={(results, streamResults, loadMoreData) => {
           const res = this.state.res.concat(results);
-          if (!results.length || res.length === 5000) {
+          if (!results.length || res.length >= 9980) {
             this.exec(res);
           } else {
             this.setState({ page: (this.state.page += 1), res });


### PR DESCRIPTION
Bon alors ES n'aime pas qu'on exporte plus de 10000 notices. Et quand on en exporte 10000, parfois ça fait une requête sur un peu plus. Je pense que cette limite est arbitraire et en mettant à 5000 ça ne changera rien pour les users : c'était une limite arbitraire, maintenant il y en a une autre. S'ils veulent faire plusieurs exports, c'est easy avec le tri, les numéros de REF, etc.