### PR TITLE
try to understand POPDATAGOUVFR-6K

### DIFF
--- a/src/services/request.js
+++ b/src/services/request.js
@@ -82,7 +82,7 @@ class request {
               if (data.success) {
                 resolve(data);
               } else {
-                reject(data.msg);
+                reject(data);
               }
             })
             .catch(e => {


### PR DESCRIPTION
Cette erreur: https://sentry.data.gouv.fr/betagouvfr/popdatagouvfr/issues/644727/events/ n'est pas compréhensible car elle ne contient qu'un message vide. Pour mieux la comprendre, il faut avoir le data en entier.